### PR TITLE
Remove unused forgerock-eidas-psd2-sdk-cert dependencies

### DIFF
--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -103,10 +103,6 @@
             <artifactId>brave</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.forgerock</groupId>
-            <artifactId>forgerock-eidas-psd2-cert-sdk</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
         </dependency>


### PR DESCRIPTION
- The library has moved and the groupId and artifactId have changed so
in order to update to the latest parent pom these dependencies must be
updated or, if not needed, removed. In this case they are not needed.