### PR TITLE
Remove spring boot plugin

### DIFF
--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -98,20 +98,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <executable>true</executable>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build-info</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
The plugin causes a fat jar to be built. We do not really care if it's a
fat jar because we'd run it from intellij. The fat jars take up a lot of
bintray space