### PR TITLE
Use the ForgeCloud access token to update ob-deploy release values

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "forgeCloud/ob-deploy"
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ secrets.FORGECLOUD_ACCESS_TOKEN }}
           path: ob-deploy
       - name: Commit ob-deploy version update
         working-directory: ./ob-deploy
@@ -117,14 +117,14 @@ jobs:
         uses: benjefferies/branch-protection-bot@master
         if: always()
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
+          access-token: ${{ secrets.FORGECLOUD_ACCESS_TOKEN }}
           enforce_admins: false
           owner: forgeCloud
           repo: ob-deploy
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.ACCESS_TOKEN }}
+          github_token: ${{ secrets.FORGECLOUD_ACCESS_TOKEN }}
           directory: ./ob-deploy
           repository: "forgeCloud/ob-deploy"
           branch: master
@@ -132,7 +132,7 @@ jobs:
         uses: benjefferies/branch-protection-bot@master
         if: always()
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
+          access-token: ${{ secrets.FORGECLOUD_ACCESS_TOKEN }}
           enforce_admins: true
           owner: forgeCloud
           repo: ob-deploy


### PR DESCRIPTION
Fix for #111 