### PR TITLE
Push Docker images to GCR instead of Codefresh

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+        echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+        echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+        docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+        echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+        docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+        echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+        echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   metrics-services" >> /etc/hosts'
-        echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+        echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-ui:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/analytics/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION
   build_analytics_backend:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-node:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/analytics/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,10 +54,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/analytics-ui:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/analytics/docker/Dockerfile -t r.cfcr.io/openbanking/obri/analytics-ui:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/analytics-ui:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/analytics-ui:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/analytics/docker/Dockerfile -t eu.gcr.io/openbanking/obri/analytics-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/analytics-ui:$BUILD_VERSION
   build_analytics_backend:
     name: Build Analytics Backend
     runs-on: ubuntu-latest
@@ -81,10 +81,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/analytics-node:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/analytics/docker/Dockerfile-server -t r.cfcr.io/openbanking/obri/analytics-node:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/analytics-node:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/analytics-node:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/analytics/docker/Dockerfile-server -t eu.gcr.io/openbanking/obri/analytics-node:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/analytics-node:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,10 +54,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/analytics-ui:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-ui:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/analytics/docker/Dockerfile -t eu.gcr.io/openbanking/obri/analytics-ui:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/analytics-ui:$BUILD_VERSION
+          docker build -f projects/analytics/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION
   build_analytics_backend:
     name: Build Analytics Backend
     runs-on: ubuntu-latest
@@ -81,10 +81,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/analytics-node:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-node:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/analytics/docker/Dockerfile-server -t eu.gcr.io/openbanking/obri/analytics-node:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/analytics-node:$BUILD_VERSION
+          docker build -f projects/analytics/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-ui:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/analytics/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION
   build_analytics_backend:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-node:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/analytics/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-ui:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/analytics/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/analytics-ui:$BUILD_VERSION
   build_analytics_backend:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/analytics-node:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/analytics/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/analytics-node:$BUILD_VERSION
   update_ob_deploy:


### PR DESCRIPTION
Push/pull Docker images to/from GCR instead of Codefresh. This references a new Github secret called `GCR_JSON_KEY` which is a new access token for Google Cloud with a limited scope for the container registry.

Part of https://github.com/ForgeCloud/ob-deploy/issues/468