### PR TITLE
Create release 1.3.5

### DIFF
--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.5</version>
+        <version>1.3.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.5-SNAPSHOT</version>
+        <version>1.3.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.5</version>
+        <version>1.3.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.5-SNAPSHOT</version>
+        <version>1.3.5</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.5-SNAPSHOT</version>
+    <version>1.3.5</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>HEAD</tag>
+        <tag>1.3.5</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>1.3.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
793: Use v 1.2.7 of openbanking commons 
https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.2.7

Fixes;
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793