### PR TITLE
793: Fix more issues with DirectorySoftwareStatement serialisation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.8</ob-common.version>
-        <ob-client.version>1.2.8</ob-client.version>
-        <ob-jwkms.version>1.2.7</ob-jwkms.version>
-        <ob-auth.version>1.1.7</ob-auth.version>
+        <ob-common.version>1.2.9</ob-common.version>
+        <ob-client.version>1.2.9</ob-client.version>
+        <ob-jwkms.version>1.2.8</ob-jwkms.version>
+        <ob-auth.version>1.1.8</ob-auth.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140