### PR TITLE
Create release 1.3.7

### DIFF
--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>1.3.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.7</version>
+        <version>1.3.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>1.3.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.7</version>
+        <version>1.3.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>1.3.7</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.7-SNAPSHOT</version>
+    <version>1.3.7</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>HEAD</tag>
+        <tag>1.3.7</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
793: Fix more issues with DirectorySoftwareStatement serialisation

Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140