### PR TITLE
Release 1.3.8 with 796: add matls checks to dcr code

### DIFF
--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.8</version>
+        <version>1.3.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.8-SNAPSHOT</version>
+        <version>1.3.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.8</version>
+        <version>1.3.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.8-SNAPSHOT</version>
+        <version>1.3.8</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.8-SNAPSHOT</version>
+    <version>1.3.8</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>HEAD</tag>
+        <tag>1.3.8</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.8</version>
+    <version>1.3.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>1.3.8</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.9</ob-common.version>
-        <ob-client.version>1.2.9</ob-client.version>
-        <ob-jwkms.version>1.2.8</ob-jwkms.version>
-        <ob-auth.version>1.1.8</ob-auth.version>
+        <ob-common.version>1.2.10</ob-common.version>
+        <ob-client.version>1.2.10</ob-client.version>
+        <ob-jwkms.version>1.2.9</ob-jwkms.version>
+        <ob-auth.version>1.1.9</ob-auth.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
796: Add MATLS checks to DCR code

Common code needed to perform MATLS checks to ensure the MATLS transport
cert presented for registration and the software statement being used
for registration were issed to the same ApiClient (TPP)

Issue: https://github.com/ForgeCloud/ob-deploy/issues/796