### PR TITLE
45: Use latest uk-datastore with 3.1.8r5 swagger generated models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.4</version>
+        <version>1.2.5</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.12</ob-common.version>
-        <ob-client.version>1.2.12</ob-client.version>
-        <ob-jwkms.version>1.2.11</ob-jwkms.version>
-        <ob-auth.version>1.1.11</ob-auth.version>
+        <ob-common.version>1.2.13</ob-common.version>
+        <ob-client.version>1.2.13</ob-client.version>
+        <ob-jwkms.version>1.2.12</ob-jwkms.version>
+        <ob-auth.version>1.1.12</ob-auth.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45