### PR TITLE
45: Release 1.3.12 to use fixed uk-datamodel for 3.1.8

### DIFF
--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.12</version>
+        <version>1.3.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-core/pom.xml
+++ b/forgerock-openbanking-analytics-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.12-SNAPSHOT</version>
+        <version>1.3.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.12</version>
+        <version>1.3.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-sample/pom.xml
+++ b/forgerock-openbanking-analytics-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.analytics</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-        <version>1.3.12-SNAPSHOT</version>
+        <version>1.3.12</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.12-SNAPSHOT</version>
+    <version>1.3.12</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>HEAD</tag>
+        <tag>1.3.12</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Analytics</name>
     <groupId>com.forgerock.openbanking.analytics</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-analytics</artifactId>
-    <version>1.3.12</version>
+    <version>1.3.13-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -106,7 +106,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-analytics.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-analytics.git</url>
-        <tag>1.3.12</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.13</ob-common.version>
-        <ob-client.version>1.2.13</ob-client.version>
-        <ob-jwkms.version>1.2.12</ob-jwkms.version>
-        <ob-auth.version>1.1.12</ob-auth.version>
+        <ob-common.version>1.2.14</ob-common.version>
+        <ob-client.version>1.2.14</ob-client.version>
+        <ob-jwkms.version>1.2.13</ob-jwkms.version>
+        <ob-auth.version>1.1.13</ob-auth.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45